### PR TITLE
Fixing bug: raising exception when calling PropertiesUtils::getEncryp…

### DIFF
--- a/src/main/java/com/webank/weid/demo/common/util/PropertiesUtils.java
+++ b/src/main/java/com/webank/weid/demo/common/util/PropertiesUtils.java
@@ -100,6 +100,6 @@ public class PropertiesUtils {
      * @return encryptType
      */
     public static String getEncryptType() {
-       return PropertyUtils.getProperty("encrypt.type");
+       return getProperty("encrypt.type");
     }
 }


### PR DESCRIPTION
实现类com.webank.weid.demo.common.util.PropertiesUtils 下的函数 public static String getEncryptType()实现有bug，
会导致无法获取application.properties配置文件中的encrypt.type参数，
应该修改如下：
public static String getEncryptType() {
return getProperty("encrypt.type");
}